### PR TITLE
Add FlashAttention module with implementation task list

### DIFF
--- a/flash-attention/Readme.md
+++ b/flash-attention/Readme.md
@@ -1,0 +1,9 @@
+# Flash Attention implementation from scratch
+
+## Tasks
+
+- [ ] Understand why vanilla attention is IO-bound, GPU memory hierarchy, tiling, online softmax, and the logsumexp trick
+- [ ] Implement FlashAttention forward pass in pure PyTorch using `torch.autograd.Function`
+- [ ] Write the Triton forward kernel with block pointers and causal masking
+- [ ] Implement the backward pass — D vector trick, PyTorch + `torch.compile`, then Triton backward kernel
+- [ ] (Stretch) Implement FA2 in NVIDIA cuTile on Blackwell


### PR DESCRIPTION
## Summary
- Adds the `flash-attention/` directory with a Readme outlining the implementation roadmap
- Tasks cover: vanilla attention concepts, PyTorch implementation, Triton forward/backward kernels, and a stretch goal for cuTile on Blackwell